### PR TITLE
fix: move integration tests to correct directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,5 @@ jobs:
       run: cargo clippy
     - name: Unit Tests
       run: cargo test --lib
+    - name: Integration Tests
+      run: cargo test --test '*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,6 @@ jobs:
     - name: Linting
       run: cargo clippy
     - name: Unit Tests
-      run: cargo test --lib
+      run: cargo test --lib --color always
     - name: Integration Tests
-      run: cargo test --test '*'
+      run: cargo test --test '*' --color always

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,5 +31,5 @@ jobs:
       run: cargo check
     - name: Linting
       run: cargo clippy
-    - name: Test
-      run: cargo test
+    - name: Unit Tests
+      run: cargo test --lib

--- a/sec/src/lib/sec_state_machine/ingestion/retrieval/mod.rs
+++ b/sec/src/lib/sec_state_machine/ingestion/retrieval/mod.rs
@@ -160,18 +160,6 @@ mod tests {
     }
 
     #[test]
-    fn should_return_true_when_state_has_computed_the_output() {
-        let mut retrieval_state = Retrieval::default();
-
-        let expected_result = true;
-
-        retrieval_state.compute_output_data();
-        let result = retrieval_state.has_output_data_been_computed();
-
-        assert_eq!(result, expected_result);
-    }
-
-    #[test]
     fn should_return_default_context_data_when_in_initial_state() {
         let retrieval_state = Retrieval::default();
 
@@ -275,18 +263,6 @@ mod tests {
         let expected_result = retrieval_state.get_context_data();
 
         let result = ref_to_retrieval_state.get_context_data();
-
-        assert_eq!(result, expected_result);
-    }
-
-    #[test]
-    fn should_return_true_when_reference_state_has_computed_the_output() {
-        let ref_to_retrieval_state = &mut Retrieval::default();
-
-        let expected_result = true;
-
-        ref_to_retrieval_state.compute_output_data();
-        let result = ref_to_retrieval_state.has_output_data_been_computed();
 
         assert_eq!(result, expected_result);
     }

--- a/sec/tests/integration_tests.rs
+++ b/sec/tests/integration_tests.rs
@@ -1,0 +1,26 @@
+use sec::sec_state_machine::State;
+use sec::sec_state_machine::ingestion::retrieval::Retrieval;
+
+#[test]
+fn should_return_true_when_state_has_computed_the_output() {
+    let mut retrieval_state = Retrieval::default();
+
+    let expected_result = true;
+
+    retrieval_state.compute_output_data();
+    let result = retrieval_state.has_output_data_been_computed();
+
+    assert_eq!(result, expected_result);
+}
+
+#[test]
+fn should_return_true_when_reference_state_has_computed_the_output() {
+    let ref_to_retrieval_state = &mut Retrieval::default();
+
+    let expected_result = true;
+
+    ref_to_retrieval_state.compute_output_data();
+    let result = ref_to_retrieval_state.has_output_data_been_computed();
+
+    assert_eq!(result, expected_result);
+}

--- a/sec/tests/integration_tests.rs
+++ b/sec/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use sec::sec_state_machine::State;
 use sec::sec_state_machine::ingestion::retrieval::Retrieval;
 
 #[test]
-fn should_return_true_when_state_has_computed_the_output() {
+fn should_return_true_when_retrieval_state_has_computed_the_output() {
     let mut retrieval_state = Retrieval::default();
 
     let expected_result = true;
@@ -14,7 +14,7 @@ fn should_return_true_when_state_has_computed_the_output() {
 }
 
 #[test]
-fn should_return_true_when_reference_state_has_computed_the_output() {
+fn should_return_true_when_reference_of_retrieval_state_has_computed_the_output() {
     let ref_to_retrieval_state = &mut Retrieval::default();
 
     let expected_result = true;


### PR DESCRIPTION
Moved the tests that fail when an Internet connection is needed to the correct directory. They should be integration tests as they depend on an external API.