### PR TITLE
refactor: make sample state context more flexible by implementing ToS…

### DIFF
--- a/state_machine/src/state_machine/state/context_data/mod.rs
+++ b/state_machine/src/state_machine/state/context_data/mod.rs
@@ -102,8 +102,8 @@ mod tests {
     fn should_update_context_to_latest_specified_string_when_multiple_updates_in_builder() {
         let mut context = SampleStateContext::default();
         let update = SampleStateContextUpdaterBuilder::default()
-            .context_data(String::from("First Update!"))
-            .context_data(String::from("Latest Update!"))
+            .context_data("First Update!")
+            .context_data("Latest Update!")
             .build();
 
         let expected_result = &SampleStateContext::new(String::from("Latest Update!"));

--- a/state_machine/src/tests/common/sample_state/sample_state_context.rs
+++ b/state_machine/src/tests/common/sample_state/sample_state_context.rs
@@ -38,8 +38,8 @@ impl SampleStateContextUpdaterBuilder {
         Self { context_data: None }
     }
 
-    pub fn context_data(mut self, context_data: String) -> Self {
-        self.context_data = Some(context_data);
+    pub fn context_data(mut self, context_data: impl ToString) -> Self {
+        self.context_data = Some(context_data.to_string());
         self
     }
 


### PR DESCRIPTION
…tring for its context_data instead of String