### PR TITLE
docs: change link from google drive to notion

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,8 @@ Make sure to change the **placeholders** in the commands.
    git checkout -b your-feature-name
    ```
 ### Code guidelines
-Make sure the code guidelines outlined [here](https://docs.google.com/document/d/15cCsiH9SULp1dKRUhxhNc5mDCajH6r4uaeoqiJyRVcQ/) are followed at all times. This saves us a lot of time.
+Make sure the code guidelines outlined [here](
+https://www.notion.so/Arkad-Software-Development-Guidelines-214cfe3cc9fb809082a0d15d3e6036cc) are followed at all times. This saves us a lot of time.
 
 ### Submitting a Pull Request
 1. Make sure your branch is up to date:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,6 @@ Please include a summary of the changes you made.
 
 # Checklist:
 
-- [ ] The Software Development Guidelines outlined [here](https://docs.google.com/document/d/15cCsiH9SULp1dKRUhxhNc5mDCajH6r4uaeoqiJyRVcQ/) are followed
+- [ ] The Software Development Guidelines outlined [here](
+https://www.notion.so/Arkad-Software-Development-Guidelines-214cfe3cc9fb809082a0d15d3e6036cc) are followed
 


### PR DESCRIPTION
# Description

Changes the link for the software development guidelines from Google Drive to Notion

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] The Software Development Guidelines outlined [here](https://docs.google.com/document/d/15cCsiH9SULp1dKRUhxhNc5mDCajH6r4uaeoqiJyRVcQ/) are followed

