### PR TITLE
Feat/transition vcf psr

### DIFF
--- a/sec/src/bin/extraction/main.rs
+++ b/sec/src/bin/extraction/main.rs
@@ -65,8 +65,9 @@ async fn main() {
     println!("\n=======================================================");
     println!("Transition Extract from ValidateCikFormat to PrepareSecRequest:");
 
-    let super_state = super_state.transition_to_next_state_sec().expect("Transition should succeed");
+    let super_state = super_state
+        .transition_to_next_state_sec()
+        .expect("Transition should succeed");
 
     println!("{}", super_state.get_state_name().to_string());
-
 }

--- a/sec/src/bin/extraction/main.rs
+++ b/sec/src/bin/extraction/main.rs
@@ -33,7 +33,7 @@ async fn main() {
                 .clone(),
             "Test User Agent test@example.com".to_string(),
         ),
-        PrepareSecRequestContext::new(),
+        PrepareSecRequestContext::default(),
     );
     println!("{:.500}", prepare_sec_request.to_string().as_str());
     prepare_sec_request

--- a/sec/src/bin/extraction/main.rs
+++ b/sec/src/bin/extraction/main.rs
@@ -47,7 +47,7 @@ async fn main() {
     println!("\n=======================================================");
     println!("Initial Extract SuperState:");
 
-    let mut super_state = ExtractSuperState::new("1067983");
+    let mut super_state = ExtractSuperState::<ValidateCikFormat>::new("1067983");
 
     super_state
         .compute_output_data_async()
@@ -61,4 +61,12 @@ async fn main() {
         .validated_cik
         .value();
     println!("State 1 Output: Validated CIK is {validated_cik}");
+
+    println!("\n=======================================================");
+    println!("Transition Extract from ValidateCikFormat to PrepareSecRequest:");
+
+    let super_state = super_state.transition_to_next_state_sec().expect("Transition should succeed");
+
+    println!("{}", super_state.get_state_name().to_string());
+
 }

--- a/sec/src/lib/implementations/states/extract/mod.rs
+++ b/sec/src/lib/implementations/states/extract/mod.rs
@@ -1,15 +1,30 @@
 //! # Extract State Module
 //!
-//! This module contains state implementations responsible for the extraction and initial validation of raw SEC filings data.
-//! It provides the entry point for the Extract phase in the SEC state machine ETL workflow.
+//! This module provides state implementations for the extraction phase of the SEC filings ETL workflow.
+//! It handles validation of raw input data and preparation of SEC API requests through a hierarchical super-state.
 //!
-//! ## Submodules
-//! - [`validate_cik_format`]: Implements a state for validating and extracting CIK (Central Index Key) information from SEC filings, including format checks and normalization routines.
-//! - [`prepare_sec_request`]: Contains a state for preparing SEC requests, including constructing the necessary parameters and handling client creation errors.
+//! ## Components
+//! - [`validate_cik_format`]: Validates and normalizes CIK (Central Index Key) strings to proper 10-digit format.
+//! - [`prepare_sec_request`]: Creates HTTP clients and prepares request objects for SEC API calls.
+//! - [`ExtractSuperState`]: Super-state that orchestrates the extraction workflow and state transitions.
 //!
-//! The extract states are designed to be composed within state machines, enabling robust, testable, and extensible data ingestion pipelines for SEC filings processing.
+//! ## State Flow
+//! The extraction follows this progression: [`ValidateCikFormat`] → [`PrepareSecRequest`]
 //!
-//! See the documentation for each submodule for details on their specific responsibilities and usage.
+//! ## Example
+//! ```rust
+//! use sec::implementations::states::extract::*;
+//! use sec::implementations::states::extract::validate_cik_format::ValidateCikFormat;
+//! use sec::prelude::*;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut extract_state = ExtractSuperState::<ValidateCikFormat>::new("1234567890");
+//!     extract_state.compute_output_data_async().await?;
+//!     let next_state = extract_state.transition_to_next_state_sec()?;
+//!     Ok(())
+//! }
+//! ```
 
 pub mod prepare_sec_request;
 pub mod validate_cik_format;
@@ -30,6 +45,9 @@ use async_trait::async_trait;
 use crate::prelude::*;
 use state_maschine::prelude::{StateMachine as SMStateMachine, Transition as SMTransition};
 
+/// Data structure for the Extract super-state.
+///
+/// Currently serves as a placeholder type with unit update semantics for the [`ExtractSuperState`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtractSuperStateData;
 
@@ -47,6 +65,9 @@ impl StateData for ExtractSuperStateData {
     }
 }
 
+/// Context data structure for the Extract super-state.
+///
+/// Provides configuration and runtime context for the [`ExtractSuperState`], including retry policies.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtractSuperStateContext;
 
@@ -64,7 +85,16 @@ impl ContextData for ExtractSuperStateContext {
     }
 }
 
-/// The `ExtractSuperState` is a hierarchical state that manages the states of the extraction phase.
+/// A hierarchical super-state that orchestrates the extraction phase of the SEC ETL pipeline.
+///
+/// Manages progression through extraction states like [`ValidateCikFormat`] and [`PrepareSecRequest`],
+/// providing type-safe transitions and unified state machine interfaces.
+///
+/// # Type Parameter
+/// - `S`: The current active state, which must implement the [`State`] trait
+///
+/// # State Transitions
+/// Supports transitions: `ValidateCikFormat` → `PrepareSecRequest`
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtractSuperState<S: State> {
     current_state: S,
@@ -208,5 +238,173 @@ impl SMTransition<ValidateCikFormat, PrepareSecRequest> for ExtractSuperState<Va
         Err(
             "Use transition_to_next_state_sec() for SEC-specific transitions with rich error handling",
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shared::cik::Cik;
+    use crate::shared::user_agent::constants::DEFAULT_SEC_USER_AGENT;
+    use pretty_assertions::assert_eq;
+    use std::{fmt::Debug, hash::Hash};
+    use tokio;
+
+    #[test]
+    fn should_return_super_state_name_with_current_state_when_in_validate_cik_format_state() {
+        let input_cik = "1234567890";
+        let super_state = ExtractSuperState::<ValidateCikFormat>::new(input_cik);
+
+        let expected_result = "Extract SuperState (Current: CIK Format Validation)";
+
+        let result = super_state.get_state_name().to_string();
+
+        assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn should_return_super_state_name_with_current_state_when_in_prepare_sec_request_state() {
+        let cik = Cik::new("1234567890").expect("Hardcoded CIK should be valid");
+        let user_agent = DEFAULT_SEC_USER_AGENT.to_string();
+        let super_state = ExtractSuperState::<PrepareSecRequest>::new(cik, user_agent);
+
+        let expected_result = "Extract SuperState (Current: Prepare SEC Request)";
+
+        let result = super_state.get_state_name().to_string();
+
+        assert_eq!(result, expected_result);
+    }
+
+
+    #[test]
+    fn should_access_current_validate_cik_format_state_from_super_state() {
+        let input_cik = "1234567890";
+        let super_state = ExtractSuperState::<ValidateCikFormat>::new(input_cik);
+
+        let expected_state_name = "CIK Format Validation";
+
+        let result = super_state.get_current_state().get_state_name().to_string();
+
+        assert_eq!(result, expected_state_name);
+    }
+
+    #[test]
+    fn should_access_current_prepare_sec_request_state_from_super_state() {
+        let cik = Cik::new("1234567890").expect("Hardcoded CIK should be valid");
+        let user_agent = DEFAULT_SEC_USER_AGENT.to_string();
+        let super_state = ExtractSuperState::<PrepareSecRequest>::new(cik, user_agent);
+
+        let expected_state_name = "Prepare SEC Request";
+
+        let result = super_state.get_current_state().get_state_name().to_string();
+
+        assert_eq!(result, expected_state_name);
+    }
+
+    #[tokio::test]
+    async fn should_delegate_computation_to_current_state_when_computing_output_data() {
+        let input_cik = "1234567890";
+        let mut super_state = ExtractSuperState::<ValidateCikFormat>::new(input_cik);
+
+        let expected_result = Ok(());
+
+        let result = super_state.compute_output_data_async().await;
+
+        assert_eq!(result, expected_result);
+        assert!(super_state.get_current_state().has_output_data_been_computed());
+    }
+
+    #[tokio::test]
+    async fn should_transition_from_validate_cik_format_to_prepare_sec_request_state() {
+        let input_cik = "1234567890";
+        let mut super_state = ExtractSuperState::<ValidateCikFormat>::new(input_cik);
+
+        super_state.compute_output_data_async().await.expect("Should compute output data");
+
+        let expected_result_type = "Extract SuperState (Current: Prepare SEC Request)";
+
+        let result = super_state.transition_to_next_state_sec().unwrap();
+
+        assert_eq!(result.get_state_name().to_string(), expected_result_type);
+    }
+
+    #[tokio::test]
+    async fn shoud_fail_transition_when_output_data_not_yet_computed() {
+        let input_cik = "1234567890";
+        let super_state = ExtractSuperState::<ValidateCikFormat>::new(input_cik);
+
+        let result = super_state.transition_to_next_state_sec();
+
+        assert!(result.is_err());
+    }
+
+    const fn implements_auto_traits<T: Sized + Send + Sync + Unpin>() {}
+    #[test]
+    const fn should_implement_auto_traits_for_validate_cik_format_super_state() {
+        implements_auto_traits::<ExtractSuperState<ValidateCikFormat>>();
+    }
+
+    #[test]
+    const fn should_implement_auto_traits_for_prepare_sec_request_super_state() {
+        implements_auto_traits::<ExtractSuperState<PrepareSecRequest>>();
+    }
+
+    const fn implements_send<T: Send>() {}
+    const fn implements_sync<T: Sync>() {}
+
+    #[test]
+    const fn should_be_thread_safe_for_validate_cik_format_super_state() {
+        implements_send::<ExtractSuperState<ValidateCikFormat>>();
+        implements_sync::<ExtractSuperState<ValidateCikFormat>>();
+    }
+
+    #[test]
+    const fn should_be_thread_safe_for_prepare_sec_request_super_state() {
+        implements_send::<ExtractSuperState<PrepareSecRequest>>();
+        implements_sync::<ExtractSuperState<PrepareSecRequest>>();
+    }
+
+    const fn implements_debug<T: Debug>() {}
+    #[test]
+    const fn should_implement_debug_for_validate_cik_format_super_state() {
+        implements_debug::<ExtractSuperState<ValidateCikFormat>>();
+    }
+
+    #[test]
+    const fn should_implement_debug_for_prepare_sec_request_super_state() {
+        implements_debug::<ExtractSuperState<PrepareSecRequest>>();
+    }
+
+    const fn implements_clone<T: Clone>() {}
+    #[test]
+    const fn should_implement_clone_for_validate_cik_format_super_state() {
+        implements_clone::<ExtractSuperState<ValidateCikFormat>>();
+    }
+
+    #[test]
+    const fn should_implement_clone_for_prepare_sec_request_super_state() {
+        implements_clone::<ExtractSuperState<PrepareSecRequest>>();
+    }
+
+    const fn implements_partial_eq<T: PartialEq>() {}
+    #[test]
+    const fn should_implement_partial_eq_for_validate_cik_format_super_state() {
+        implements_partial_eq::<ExtractSuperState<ValidateCikFormat>>();
+    }
+
+    #[test]
+    const fn should_implement_partial_eq_for_prepare_sec_request_super_state() {
+        implements_partial_eq::<ExtractSuperState<PrepareSecRequest>>();
+    }
+
+    const fn implements_hash<T: Hash>() {}
+    #[test]
+    const fn should_implement_hash_for_validate_cik_format_super_state() {
+        implements_hash::<ExtractSuperState<ValidateCikFormat>>();
+    }
+
+    #[test]
+    const fn should_implement_hash_for_prepare_sec_request_super_state() {
+        implements_hash::<ExtractSuperState<PrepareSecRequest>>();
     }
 }

--- a/sec/src/lib/implementations/states/extract/mod.rs
+++ b/sec/src/lib/implementations/states/extract/mod.rs
@@ -16,19 +16,19 @@ pub mod validate_cik_format;
 
 use crate::error::State as StateError;
 use crate::error::state_machine::transition::Transition as TransitionError;
-use crate::implementations::states::extract::validate_cik_format::{
-    ValidateCikFormatContext, ValidateCikFormatInputData,
-};
 use crate::implementations::states::extract::prepare_sec_request::{
     PrepareSecRequestContext, PrepareSecRequestInputData,
+};
+use crate::implementations::states::extract::validate_cik_format::{
+    ValidateCikFormatContext, ValidateCikFormatInputData,
 };
 
 use async_trait::async_trait;
 
 use crate::prelude::*;
-use state_maschine::prelude::{Transition as SMTransition, StateMachine as SMStateMachine};
-use validate_cik_format::ValidateCikFormat;
 use prepare_sec_request::PrepareSecRequest;
+use state_maschine::prelude::{StateMachine as SMStateMachine, Transition as SMTransition};
+use validate_cik_format::ValidateCikFormat;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtractSuperStateData;
@@ -143,7 +143,7 @@ impl ExtractSuperState<ValidateCikFormat> {
 
 impl ExtractSuperState<PrepareSecRequest> {
     #[must_use]
-    pub fn new(validated_cik: crate::shared::cik::Cik, user_agent: String) -> Self {
+    pub const fn new(validated_cik: crate::shared::cik::Cik, user_agent: String) -> Self {
         let psr_input = PrepareSecRequestInputData::new(validated_cik, user_agent);
         let psr_context = PrepareSecRequestContext::new();
 
@@ -158,18 +158,20 @@ impl ExtractSuperState<PrepareSecRequest> {
 
 impl Transition<ValidateCikFormat, PrepareSecRequest> for ExtractSuperState<ValidateCikFormat> {
     fn transition_to_next_state_sec(self) -> Result<Self::NewStateMachine, TransitionError> {
-        
         let output_data = self
             .current_state
             .get_output_data()
             .ok_or(TransitionError::FailedOutputConversion)?;
-        
+
         let validated_cik = output_data.validated_cik.clone();
-        
+
         // Use default user agent for now
         let user_agent = "SEC Extraction Agent contact@example.com".to_string();
-        
-        Ok(ExtractSuperState::<PrepareSecRequest>::new(validated_cik, user_agent))
+
+        Ok(ExtractSuperState::<PrepareSecRequest>::new(
+            validated_cik,
+            user_agent,
+        ))
     }
 }
 
@@ -178,6 +180,8 @@ impl SMTransition<ValidateCikFormat, PrepareSecRequest> for ExtractSuperState<Va
 
     fn transition_to_next_state(self) -> Result<Self::NewStateMachine, &'static str> {
         // Placeholder implementation - use transition_to_next_state_sec() for actual functionality
-        Err("Use transition_to_next_state_sec() for SEC-specific transitions with rich error handling")
+        Err(
+            "Use transition_to_next_state_sec() for SEC-specific transitions with rich error handling",
+        )
     }
 }

--- a/sec/src/lib/implementations/states/extract/mod.rs
+++ b/sec/src/lib/implementations/states/extract/mod.rs
@@ -149,7 +149,7 @@ impl TryFrom<ValidateCikFormat> for PrepareSecRequest {
             return Err(TransitionError::FailedOutputConversion);
         }
         let output_data = state.get_output_data().expect("Output data of `ValidateCikFormat` should always be existing when triggering a transition to next state.").clone();
-        
+
         let new_context: PrepareSecRequestContext = output_data.clone().into();
         let new_input: PrepareSecRequestInputData = output_data.into();
 

--- a/sec/src/lib/implementations/states/extract/mod.rs
+++ b/sec/src/lib/implementations/states/extract/mod.rs
@@ -20,7 +20,7 @@ use crate::implementations::states::extract::prepare_sec_request::{
     PrepareSecRequestContext, PrepareSecRequestInputData,
 };
 use crate::implementations::states::extract::validate_cik_format::{
-    ValidateCikFormatContext, ValidateCikFormatInputData,ValidateCikFormatOutputData
+    ValidateCikFormatContext, ValidateCikFormatInputData, ValidateCikFormatOutputData,
 };
 
 use async_trait::async_trait;
@@ -134,10 +134,12 @@ impl From<ValidateCikFormatContext> for PrepareSecRequestContext {
 
 impl From<ValidateCikFormatOutputData> for PrepareSecRequestInputData {
     fn from(output_data: ValidateCikFormatOutputData) -> Self {
-        Self::new(output_data.validated_cik, "SEC Extraction Agent contact@example.com".to_string())
+        Self::new(
+            output_data.validated_cik,
+            "SEC Extraction Agent contact@example.com".to_string(),
+        )
     }
 }
-
 
 impl TryFrom<ValidateCikFormat> for PrepareSecRequest {
     type Error = TransitionError;
@@ -182,7 +184,6 @@ impl ExtractSuperState<PrepareSecRequest> {
         }
     }
 }
-
 
 impl Transition<ValidateCikFormat, PrepareSecRequest> for ExtractSuperState<ValidateCikFormat> {
     fn transition_to_next_state_sec(self) -> Result<Self::NewStateMachine, TransitionError> {

--- a/sec/src/lib/implementations/states/extract/mod.rs
+++ b/sec/src/lib/implementations/states/extract/mod.rs
@@ -17,18 +17,18 @@ pub mod validate_cik_format;
 use crate::error::State as StateError;
 use crate::error::state_machine::transition::Transition as TransitionError;
 use crate::implementations::states::extract::prepare_sec_request::{
-    PrepareSecRequestContext, PrepareSecRequestInputData,
+    PrepareSecRequest, PrepareSecRequestContext, PrepareSecRequestInputData,
 };
 use crate::implementations::states::extract::validate_cik_format::{
-    ValidateCikFormatContext, ValidateCikFormatInputData, ValidateCikFormatOutputData,
+    ValidateCikFormat, ValidateCikFormatContext, ValidateCikFormatInputData,
+    ValidateCikFormatOutputData,
 };
+use crate::shared::user_agent::constants::DEFAULT_SEC_USER_AGENT;
 
 use async_trait::async_trait;
 
 use crate::prelude::*;
-use prepare_sec_request::PrepareSecRequest;
 use state_maschine::prelude::{StateMachine as SMStateMachine, Transition as SMTransition};
-use validate_cik_format::ValidateCikFormat;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtractSuperStateData;
@@ -136,7 +136,7 @@ impl From<ValidateCikFormatOutputData> for PrepareSecRequestInputData {
     fn from(output_data: ValidateCikFormatOutputData) -> Self {
         Self::new(
             output_data.validated_cik,
-            "SEC Extraction Agent contact@example.com".to_string(),
+            DEFAULT_SEC_USER_AGENT.to_string(),
         )
     }
 }

--- a/sec/src/lib/implementations/states/extract/mod.rs
+++ b/sec/src/lib/implementations/states/extract/mod.rs
@@ -275,7 +275,6 @@ mod tests {
         assert_eq!(result, expected_result);
     }
 
-
     #[test]
     fn should_access_current_validate_cik_format_state_from_super_state() {
         let input_cik = "1234567890";
@@ -311,7 +310,11 @@ mod tests {
         let result = super_state.compute_output_data_async().await;
 
         assert_eq!(result, expected_result);
-        assert!(super_state.get_current_state().has_output_data_been_computed());
+        assert!(
+            super_state
+                .get_current_state()
+                .has_output_data_been_computed()
+        );
     }
 
     #[tokio::test]
@@ -319,7 +322,10 @@ mod tests {
         let input_cik = "1234567890";
         let mut super_state = ExtractSuperState::<ValidateCikFormat>::new(input_cik);
 
-        super_state.compute_output_data_async().await.expect("Should compute output data");
+        super_state
+            .compute_output_data_async()
+            .await
+            .expect("Should compute output data");
 
         let expected_result_type = "Extract SuperState (Current: Prepare SEC Request)";
 

--- a/sec/src/lib/implementations/states/extract/prepare_sec_request/psr_context/mod.rs
+++ b/sec/src/lib/implementations/states/extract/prepare_sec_request/psr_context/mod.rs
@@ -48,7 +48,7 @@ impl PrepareSecRequestContext {
     /// Creates a new instance of the state context for SEC request preparation.
     pub const fn new(cik: Cik) -> Self {
         Self {
-            cik: cik,
+            cik,
             max_retries: 0,
         }
     }
@@ -85,7 +85,7 @@ impl SMContextData for PrepareSecRequestContext {
 
 impl fmt::Display for PrepareSecRequestContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Context Data:\nMax retries: {}", self.max_retries)
+        write!(f, "Context Data:\nCIK (validated): {}\nMax retries: {}",self.cik, self.max_retries)
     }
 }
 
@@ -109,7 +109,10 @@ impl PrepareSecRequestContextUpdaterBuilder {
     /// Creates a new [`PrepareSecRequestContextUpdaterBuilder`] with no fields set.
     #[must_use]
     pub const fn new() -> Self {
-        Self {cik: None, max_retries: None }
+        Self {
+            cik: None,
+            max_retries: None,
+        }
     }
 
     /// Sets the `max_retries` value inside the context to the provided update value.
@@ -123,7 +126,7 @@ impl PrepareSecRequestContextUpdaterBuilder {
         self
     }
 
-    pub fn cik(mut self, cik: Cik) -> Self {
+    #[must_use] pub fn cik(mut self, cik: Cik) -> Self {
         self.cik = Some(cik);
         self
     }
@@ -149,10 +152,10 @@ impl Default for PrepareSecRequestContextUpdaterBuilder {
 mod tests {
     use std::{fmt::Debug, hash::Hash};
 
-    use pretty_assertions::{assert_eq, assert_ne};
-    use state_maschine::prelude::*;
     use crate::shared::cik::Cik;
     use crate::shared::cik::constants::BERKSHIRE_HATHAWAY_CIK_RAW;
+    use pretty_assertions::{assert_eq, assert_ne};
+    use state_maschine::prelude::*;
 
     use super::{PrepareSecRequestContext, PrepareSecRequestContextUpdaterBuilder};
 
@@ -170,9 +173,13 @@ mod tests {
     #[test]
     fn should_create_different_context_with_custom_data_when_using_default_as_constructor() {
         let request_context = &PrepareSecRequestContext::default();
-        let cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
+        let cik =
+            Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
 
-        let expected_result = &PrepareSecRequestContext {cik, max_retries: 5 };
+        let expected_result = &PrepareSecRequestContext {
+            cik,
+            max_retries: 5,
+        };
 
         let result = request_context.get_context();
 
@@ -185,9 +192,13 @@ mod tests {
         let update = PrepareSecRequestContextUpdaterBuilder::new()
             .max_retries(5)
             .build();
-        let cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
+        let cik =
+            Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
 
-        let expected_result = &PrepareSecRequestContext {cik, max_retries: 5 };
+        let expected_result = &PrepareSecRequestContext {
+            cik,
+            max_retries: 5,
+        };
 
         context.update_context(update);
         let result = context.get_context();
@@ -202,9 +213,13 @@ mod tests {
             .max_retries(5)
             .max_retries(10)
             .build();
-        let cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
+        let cik =
+            Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
 
-        let expected_result = &PrepareSecRequestContext {cik, max_retries: 10 };
+        let expected_result = &PrepareSecRequestContext {
+            cik,
+            max_retries: 10,
+        };
 
         context.update_context(update);
         let result = context.get_context();

--- a/sec/src/lib/implementations/states/extract/prepare_sec_request/psr_context/mod.rs
+++ b/sec/src/lib/implementations/states/extract/prepare_sec_request/psr_context/mod.rs
@@ -33,19 +33,24 @@ use std::fmt;
 
 use state_maschine::prelude::ContextData as SMContextData;
 
+use crate::shared::cik::Cik;
 use crate::traits::state_machine::state::ContextData;
 
 #[derive(Debug, Default, Clone, PartialEq, PartialOrd, Hash, Eq, Ord)]
 /// State context for the SEC request preparation state.
 pub struct PrepareSecRequestContext {
+    pub cik: Cik,
     pub max_retries: u32,
 }
 
 impl PrepareSecRequestContext {
     #[must_use]
     /// Creates a new instance of the state context for SEC request preparation.
-    pub const fn new() -> Self {
-        Self { max_retries: 0 }
+    pub const fn new(cik: Cik) -> Self {
+        Self {
+            cik: cik,
+            max_retries: 0,
+        }
     }
 }
 
@@ -71,6 +76,10 @@ impl SMContextData for PrepareSecRequestContext {
         if let Some(max_retries) = updates.max_retries {
             self.max_retries = max_retries;
         }
+
+        if let Some(cik) = updates.cik {
+            self.cik = cik;
+        }
     }
 }
 
@@ -85,6 +94,7 @@ impl fmt::Display for PrepareSecRequestContext {
 ///
 /// Using this struct allows you to update fields of [`PrepareSecRequestContext`] in a controlled way.
 pub struct PrepareSecRequestContextUpdater {
+    pub cik: Option<Cik>,
     pub max_retries: Option<u32>,
 }
 
@@ -92,13 +102,14 @@ pub struct PrepareSecRequestContextUpdater {
 ///
 /// Use this builder to fluently construct an updater for the context.
 pub struct PrepareSecRequestContextUpdaterBuilder {
+    cik: Option<Cik>,
     max_retries: Option<u32>,
 }
 impl PrepareSecRequestContextUpdaterBuilder {
     /// Creates a new [`PrepareSecRequestContextUpdaterBuilder`] with no fields set.
     #[must_use]
     pub const fn new() -> Self {
-        Self { max_retries: None }
+        Self {cik: None, max_retries: None }
     }
 
     /// Sets the `max_retries` value inside the context to the provided update value.
@@ -112,10 +123,16 @@ impl PrepareSecRequestContextUpdaterBuilder {
         self
     }
 
+    pub fn cik(mut self, cik: Cik) -> Self {
+        self.cik = Some(cik);
+        self
+    }
+
     /// Builds the [`PrepareSecRequestContextUpdater`] with the specified fields.
     #[must_use]
-    pub const fn build(self) -> PrepareSecRequestContextUpdater {
+    pub fn build(self) -> PrepareSecRequestContextUpdater {
         PrepareSecRequestContextUpdater {
+            cik: self.cik,
             max_retries: self.max_retries,
         }
     }
@@ -134,6 +151,8 @@ mod tests {
 
     use pretty_assertions::{assert_eq, assert_ne};
     use state_maschine::prelude::*;
+    use crate::shared::cik::Cik;
+    use crate::shared::cik::constants::BERKSHIRE_HATHAWAY_CIK_RAW;
 
     use super::{PrepareSecRequestContext, PrepareSecRequestContextUpdaterBuilder};
 
@@ -149,10 +168,11 @@ mod tests {
     }
 
     #[test]
-    fn should_create_different_context_with_custom_data_when_using_new_as_constructor() {
-        let request_context = &PrepareSecRequestContext::new();
+    fn should_create_different_context_with_custom_data_when_using_default_as_constructor() {
+        let request_context = &PrepareSecRequestContext::default();
+        let cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
 
-        let expected_result = &PrepareSecRequestContext { max_retries: 5 };
+        let expected_result = &PrepareSecRequestContext {cik, max_retries: 5 };
 
         let result = request_context.get_context();
 
@@ -165,8 +185,9 @@ mod tests {
         let update = PrepareSecRequestContextUpdaterBuilder::new()
             .max_retries(5)
             .build();
+        let cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
 
-        let expected_result = &PrepareSecRequestContext { max_retries: 5 };
+        let expected_result = &PrepareSecRequestContext {cik, max_retries: 5 };
 
         context.update_context(update);
         let result = context.get_context();
@@ -181,8 +202,9 @@ mod tests {
             .max_retries(5)
             .max_retries(10)
             .build();
+        let cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW).expect("Hardcoded CIK should always be valid.");
 
-        let expected_result = &PrepareSecRequestContext { max_retries: 10 };
+        let expected_result = &PrepareSecRequestContext {cik, max_retries: 10 };
 
         context.update_context(update);
         let result = context.get_context();

--- a/sec/src/lib/implementations/states/extract/prepare_sec_request/psr_context/mod.rs
+++ b/sec/src/lib/implementations/states/extract/prepare_sec_request/psr_context/mod.rs
@@ -85,7 +85,11 @@ impl SMContextData for PrepareSecRequestContext {
 
 impl fmt::Display for PrepareSecRequestContext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Context Data:\nCIK (validated): {}\nMax retries: {}",self.cik, self.max_retries)
+        write!(
+            f,
+            "Context Data:\nCIK (validated): {}\nMax retries: {}",
+            self.cik, self.max_retries
+        )
     }
 }
 
@@ -126,7 +130,8 @@ impl PrepareSecRequestContextUpdaterBuilder {
         self
     }
 
-    #[must_use] pub fn cik(mut self, cik: Cik) -> Self {
+    #[must_use]
+    pub fn cik(mut self, cik: Cik) -> Self {
         self.cik = Some(cik);
         self
     }

--- a/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_context/mod.rs
+++ b/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_context/mod.rs
@@ -33,7 +33,7 @@ use std::fmt;
 
 use state_maschine::prelude::ContextData as SMContextData;
 
-use crate::shared::cik::constants::BERKSHIRE_HATHAWAY_CIK;
+use crate::shared::cik::constants::BERKSHIRE_HATHAWAY_CIK_RAW;
 use crate::traits::state_machine::state::ContextData;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Hash, Eq, Ord)]
@@ -96,7 +96,7 @@ impl SMContextData for ValidateCikFormatContext {
 impl Default for ValidateCikFormatContext {
     /// Returns a default context using the CIK for Berkshire Hathaway (CIK: 1067983).
     fn default() -> Self {
-        Self::new(BERKSHIRE_HATHAWAY_CIK)
+        Self::new(BERKSHIRE_HATHAWAY_CIK_RAW)
     }
 }
 
@@ -162,7 +162,7 @@ mod tests {
     use state_maschine::prelude::*;
 
     use super::{
-        BERKSHIRE_HATHAWAY_CIK, ValidateCikFormatContext, ValidateCikFormatContextUpdaterBuilder,
+        BERKSHIRE_HATHAWAY_CIK_RAW, ValidateCikFormatContext, ValidateCikFormatContextUpdaterBuilder,
     };
 
     #[test]
@@ -225,7 +225,7 @@ mod tests {
             .cik("Updated CIK!")
             .build();
 
-        let expected_result = BERKSHIRE_HATHAWAY_CIK;
+        let expected_result = BERKSHIRE_HATHAWAY_CIK_RAW;
 
         context.update_context(update);
         let result = context.get_context().cik();

--- a/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_context/mod.rs
+++ b/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_context/mod.rs
@@ -162,7 +162,8 @@ mod tests {
     use state_maschine::prelude::*;
 
     use super::{
-        BERKSHIRE_HATHAWAY_CIK_RAW, ValidateCikFormatContext, ValidateCikFormatContextUpdaterBuilder,
+        BERKSHIRE_HATHAWAY_CIK_RAW, ValidateCikFormatContext,
+        ValidateCikFormatContextUpdaterBuilder,
     };
 
     #[test]

--- a/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_data/vcf_input_data/mod.rs
+++ b/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_data/vcf_input_data/mod.rs
@@ -30,7 +30,7 @@ use std::fmt;
 use state_maschine::prelude::StateData as SMStateData;
 
 use crate::error::State as StateError;
-use crate::shared::cik::constants::BERKSHIRE_HATHAWAY_CIK;
+use crate::shared::cik::constants::BERKSHIRE_HATHAWAY_CIK_RAW;
 use crate::traits::state_machine::state::StateData;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Hash, Eq, Ord)]
@@ -98,7 +98,7 @@ impl Default for ValidateCikFormatInputData {
     /// Returns a default input using the CIK for Berkshire Hathaway (CIK: 1067983).
     fn default() -> Self {
         Self {
-            raw_cik: BERKSHIRE_HATHAWAY_CIK.to_string(),
+            raw_cik: BERKSHIRE_HATHAWAY_CIK_RAW.to_string(),
         }
     }
 }
@@ -169,7 +169,7 @@ mod tests {
     use pretty_assertions::{assert_eq, assert_ne};
 
     use super::{
-        BERKSHIRE_HATHAWAY_CIK, ValidateCikFormatInputData,
+        BERKSHIRE_HATHAWAY_CIK_RAW, ValidateCikFormatInputData,
         ValidateCikFormatInputDataUpdaterBuilder,
     };
     use crate::traits::state_machine::state::StateData;
@@ -249,7 +249,7 @@ mod tests {
     fn should_return_default_cik_when_validation_input_data_initialized_with_default() {
         let validation_state_data = &ValidateCikFormatInputData::default();
 
-        let expected_result = &BERKSHIRE_HATHAWAY_CIK.to_string();
+        let expected_result = &BERKSHIRE_HATHAWAY_CIK_RAW.to_string();
 
         let result = validation_state_data.get_state().cik();
 

--- a/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_data/vcf_output_data/mod.rs
+++ b/sec/src/lib/implementations/states/extract/validate_cik_format/vcf_data/vcf_output_data/mod.rs
@@ -31,7 +31,7 @@ use state_maschine::prelude::StateData as SMStateData;
 
 use crate::error::State as StateError;
 use crate::error::state_machine::state::InvalidCikFormat;
-use crate::shared::cik::{Cik, constants::BERKSHIRE_HATHAWAY_CIK};
+use crate::shared::cik::{Cik, constants::BERKSHIRE_HATHAWAY_CIK_RAW};
 use crate::traits::error::FromDomainError;
 use crate::traits::state_machine::state::StateData;
 
@@ -113,7 +113,7 @@ impl Default for ValidateCikFormatOutputData {
     /// Returns a default output using the CIK for Berkshire Hathaway (CIK: 1067983).
     fn default() -> Self {
         Self {
-            validated_cik: Cik::new(BERKSHIRE_HATHAWAY_CIK)
+            validated_cik: Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW)
                 .expect("Hardcoded CIK should always be valid."),
         }
     }
@@ -185,7 +185,7 @@ mod tests {
     use pretty_assertions::{assert_eq, assert_ne};
 
     use super::{
-        BERKSHIRE_HATHAWAY_CIK, Cik, ValidateCikFormatOutputData,
+        BERKSHIRE_HATHAWAY_CIK_RAW, Cik, ValidateCikFormatOutputData,
         ValidateCikFormatOutputDataUpdaterBuilder,
     };
     use crate::traits::state_machine::state::StateData;
@@ -267,7 +267,7 @@ mod tests {
     fn should_return_formatted_and_validated_default_cik_string_when_validation_output_data_initialized_with_default()
      {
         let validation_state_data = &ValidateCikFormatOutputData::default();
-        let formatted_and_validated_berkshire_cik = Cik::new(BERKSHIRE_HATHAWAY_CIK)
+        let formatted_and_validated_berkshire_cik = Cik::new(BERKSHIRE_HATHAWAY_CIK_RAW)
             .expect("Provided hardcoded CIK should always be valid.");
 
         let expected_result = formatted_and_validated_berkshire_cik.value();
@@ -282,7 +282,7 @@ mod tests {
     fn should_panic_when_comparing_valid_but_unformatted_default_cik_with_formatted_and_validated_default_output()
      {
         let validation_state_data = &ValidateCikFormatOutputData::default();
-        let expected_result = BERKSHIRE_HATHAWAY_CIK;
+        let expected_result = BERKSHIRE_HATHAWAY_CIK_RAW;
 
         let result = validation_state_data.get_state().cik();
 

--- a/sec/src/lib/shared/cik/constants.rs
+++ b/sec/src/lib/shared/cik/constants.rs
@@ -17,8 +17,15 @@
 /// according to SEC requirements.
 pub const CIK_LENGTH: usize = 10;
 
+/// The raw CIK (Central Index Key) assigned to Berkshire Hathaway Inc. by the SEC, but without leading zeroes.
+///
+/// This constant can be used in tests, examples, or as a reference value when working with CIK-related
+/// validation and parsing logic throughout the codebase.
+pub const BERKSHIRE_HATHAWAY_CIK_RAW: &str = "1067983";
+
 /// The CIK (Central Index Key) assigned to Berkshire Hathaway Inc. by the SEC.
 ///
 /// This constant can be used in tests, examples, or as a reference value when working with CIK-related
 /// validation and parsing logic throughout the codebase.
-pub const BERKSHIRE_HATHAWAY_CIK: &str = "1067983";
+pub const BERKSHIRE_HATHAWAY_CIK: &str = "0001067983";
+

--- a/sec/src/lib/shared/cik/constants.rs
+++ b/sec/src/lib/shared/cik/constants.rs
@@ -28,4 +28,3 @@ pub const BERKSHIRE_HATHAWAY_CIK_RAW: &str = "1067983";
 /// This constant can be used in tests, examples, or as a reference value when working with CIK-related
 /// validation and parsing logic throughout the codebase.
 pub const BERKSHIRE_HATHAWAY_CIK: &str = "0001067983";
-

--- a/sec/src/lib/shared/user_agent/constants.rs
+++ b/sec/src/lib/shared/user_agent/constants.rs
@@ -1,0 +1,9 @@
+//! # User Agent Constants Module
+//! This module contains constants related to user agents.
+//! These constants can be used throughout the application to ensure consistency
+//! and avoid magic strings.
+//!
+//! The following constants are defined:
+//! - `DEFAULT_SEC_USER_AGENT`: The default user agent string to use if none is provided.
+
+pub const DEFAULT_SEC_USER_AGENT: &str = "Test Company contact@test.com";

--- a/sec/src/lib/shared/user_agent/mod.rs
+++ b/sec/src/lib/shared/user_agent/mod.rs
@@ -23,6 +23,7 @@
 
 use regex::Regex;
 
+pub mod constants;
 pub mod user_agent_error;
 pub use user_agent_error::{UserAgentError, UserAgentErrorReason};
 

--- a/sec/src/lib/traits/state_machine/transition/mod.rs
+++ b/sec/src/lib/traits/state_machine/transition/mod.rs
@@ -17,6 +17,7 @@
 
 use state_maschine::prelude::Transition as SMTransition;
 
+use crate::error::state_machine::transition::Transition as TransitionError;
 use crate::traits::state_machine::state::State;
 
 /// The `Transition` trait defines a transition between two SEC state types within a state machine.
@@ -33,4 +34,21 @@ where
     T: State,
     U: State,
 {
+    /// Transitions the state machine to the next state using SEC-specific error handling.
+    ///
+    /// This method provides the same functionality as the generic `transition_to_next_state` method,
+    /// but returns SEC-specific [`TransitionError`] types instead of static strings, enabling
+    /// richer error handling and diagnostics.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(NewStateMachine)`: The updated state machine in the new state.
+    /// - `Err(TransitionError)`: A SEC-specific error describing the failure reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`TransitionError`] if the transition fails, such as:
+    /// - [`TransitionError::FailedOutputConversion`]: When the source state's output cannot be converted to the target state's input.
+    /// - [`TransitionError::FailedContextConversion`]: When the source state's context cannot be converted to the target state's context.
+    fn transition_to_next_state_sec(self) -> Result<Self::NewStateMachine, TransitionError>;
 }


### PR DESCRIPTION
# Description

Adds a transition for the Extract state from the ValidateCikFormat to the PrepareSecRequest state

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] The Software Development Guidelines outlined [here](
https://www.notion.so/Arkad-Software-Development-Guidelines-214cfe3cc9fb809082a0d15d3e6036cc) are followed

